### PR TITLE
Better days display

### DIFF
--- a/app/BRAIHelpers/BRAIHelpers.php
+++ b/app/BRAIHelpers/BRAIHelpers.php
@@ -52,7 +52,7 @@ function is_last_column(int $column) : bool {
 }
 
 function new_day(string $day) : string {
-    return '<h1 class="brai-day">' . strtoupper($day) . ' MEETINGS</h1>';
+    return '<h1 class="brai-day">' . strtoupper($day) . '</h1>';
 }
 
 function new_row() : string {

--- a/resources/views/pdf.blade.php
+++ b/resources/views/pdf.blade.php
@@ -92,11 +92,10 @@
         }
 
         .brai-day {
-            border: none;
-            background-color: #e2e0e0;
+            border: 1px solid black;
             margin: 20px 0;
             padding: 4px;
-            text-align: left;
+            text-align: center;
         }
         .brai-day h1 {
             font-size: 20px;
@@ -173,7 +172,7 @@
                     $num_column_lines = 0;
                 @endphp
             @endif
-            <div class="row"><h1 class="brai-day">{{ strtoupper($day) }} MEETINGS</h1><div class="column">
+            <div class="row"><h1 class="brai-day">{{ strtoupper($day) }}</h1><div class="column">
             @php
                 list ($row, $column, $num_column_lines) = check_new_row_column($row, $column, $num_column_lines, LINES_PER_COLUMN);
                 $num_column_lines++;
@@ -229,13 +228,13 @@
         @foreach ($days as $day => $meetings)
             @if ($loop->first)
                 @php
-                    printf('<div class="row"><div class="column"><h1 class="brai-day">%s MEETINGS</h1>', strtoupper($day));
+                    printf('<div class="row"><div class="column"><h1 class="brai-day">%s</h1>', strtoupper($day));
                     $column = 1;
                     $num_column_lines = 1;
                 @endphp
             @else
                 @php
-                    printf('<h1 class="brai-day">%s MEETINGS</h1>', strtoupper($day));
+                    printf('<h1 class="brai-day">%s</h1>', strtoupper($day));
                     $num_column_lines++;
                 @endphp
             @endif


### PR DESCRIPTION
## Description

When printed on paper, the DAYS ("MONDAY MEETINGS", "TUESDAY MEETINGS", etc) were hard to distinguish. The background does not show up well and it's hard to see where each day begins. We previously agreed to use this, but when printed I didn't like it.

This changes it back to a black border. It also removes the word "MEETINGS" which I think I redundant, and cluttered the heading, And lastly, it centers it in the box.